### PR TITLE
Create React Native skeleton for Productify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+**/node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # Productify
-iOS productivity app
+
+Productify is an iOS productivity app built with React Native and Expo. It helps users track and improve their productivity with AI-generated suggestions.
+
+## Project Structure
+- `app/` – React Native application source
+- `app/src` – core source code (screens, services, database)
+- `app/__tests__` – unit tests with Jest
+
+## Setup
+1. Install dependencies:
+   ```sh
+   cd app
+   npm install
+   ```
+2. Start the app with Expo:
+   ```sh
+   npm start
+   ```
+3. Run tests:
+   ```sh
+   npm test
+   ```
+
+## Tasks (in order of priority)
+1. **Implement secure user registration and login.** Currently passwords are stored in plaintext in SQLite; add hashing and validation.
+2. **Integrate a real GenAI API** for productivity suggestions in `src/services/genai.ts`.
+3. **Expand the dashboard** with features to track tasks and time management.
+4. **Improve database schema** to support syncing and more complex data.
+5. **Add end-to-end tests** and CI configuration.
+

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import LoginScreen from './src/screens/LoginScreen';
+import RegisterScreen from './src/screens/RegisterScreen';
+import Dashboard from './src/screens/Dashboard';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Register" component={RegisterScreen} />
+        <Stack.Screen name="Dashboard" component={Dashboard} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/app/__tests__/auth.test.ts
+++ b/app/__tests__/auth.test.ts
@@ -1,0 +1,9 @@
+import { registerUser, authenticateUser } from '../src/services/auth';
+
+describe('Auth service', () => {
+  it('registers and authenticates a user', async () => {
+    await registerUser('test@example.com', 'pass');
+    const result = await authenticateUser('test@example.com', 'pass');
+    expect(result).toBe(true);
+  });
+});

--- a/app/app.json
+++ b/app/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "Productify",
+    "slug": "productify",
+    "version": "1.0.0",
+    "platforms": ["ios"],
+    "sdkVersion": "48.0.0",
+    "entryPoint": "./App.tsx"
+  }
+}

--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/app/index.js
+++ b/app/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "productify",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "expo": "^48.0.0",
+    "expo-sqlite": "~11.1.1",
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "react-native-fetch-api": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.2",
+    "@types/react": "~18.0.27",
+    "jest": "^29.6.2",
+    "jest-expo": "^53.0.9",
+    "ts-jest": "^29.1.0",
+    "typescript": "4.9.5"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    }
+  }
+}

--- a/app/src/database/db.ts
+++ b/app/src/database/db.ts
@@ -1,0 +1,5 @@
+import * as SQLite from 'expo-sqlite';
+
+export function openDatabase() {
+  return SQLite.openDatabase('productivity.db');
+}

--- a/app/src/screens/Dashboard.tsx
+++ b/app/src/screens/Dashboard.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import { getSuggestions } from '../services/genai';
+
+export default function Dashboard() {
+  const [suggestion, setSuggestion] = React.useState('');
+
+  const fetchSuggestion = async () => {
+    const text = await getSuggestions();
+    setSuggestion(text);
+  };
+
+  return (
+    <View>
+      <Button title="Improve my productivity" onPress={fetchSuggestion} />
+      <Text>{suggestion}</Text>
+    </View>
+  );
+}

--- a/app/src/screens/LoginScreen.tsx
+++ b/app/src/screens/LoginScreen.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import { authenticateUser } from '../services/auth';
+
+export default function LoginScreen({ navigation }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = async () => {
+    const success = await authenticateUser(email, password);
+    if (success) {
+      navigation.navigate('Dashboard');
+    }
+  };
+
+  return (
+    <View>
+      <TextInput placeholder="Email" value={email} onChangeText={setEmail} />
+      <TextInput placeholder="Password" value={password} onChangeText={setPassword} secureTextEntry />
+      <Button title="Login" onPress={handleLogin} />
+      <Button title="Register" onPress={() => navigation.navigate('Register')} />
+    </View>
+  );
+}

--- a/app/src/screens/RegisterScreen.tsx
+++ b/app/src/screens/RegisterScreen.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import { registerUser } from '../services/auth';
+
+export default function RegisterScreen({ navigation }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleRegister = async () => {
+    await registerUser(email, password);
+    navigation.navigate('Login');
+  };
+
+  return (
+    <View>
+      <TextInput placeholder="Email" value={email} onChangeText={setEmail} />
+      <TextInput placeholder="Password" value={password} onChangeText={setPassword} secureTextEntry />
+      <Button title="Register" onPress={handleRegister} />
+    </View>
+  );
+}

--- a/app/src/services/auth.ts
+++ b/app/src/services/auth.ts
@@ -1,0 +1,31 @@
+import { openDatabase } from '../database/db';
+
+const db = openDatabase();
+
+db.transaction(tx => {
+  tx.executeSql(
+    'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT, password TEXT);'
+  );
+});
+
+export function registerUser(email: string, password: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    db.transaction(tx => {
+      tx.executeSql('INSERT INTO users (email, password) values (?, ?);', [email, password],
+        () => resolve(),
+        (_, err) => { reject(err); return false; }
+      );
+    });
+  });
+}
+
+export function authenticateUser(email: string, password: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    db.transaction(tx => {
+      tx.executeSql('SELECT * FROM users WHERE email = ? AND password = ?;', [email, password],
+        (_, { rows }) => resolve(rows.length > 0),
+        (_, err) => { reject(err); return false; }
+      );
+    });
+  });
+}

--- a/app/src/services/genai.ts
+++ b/app/src/services/genai.ts
@@ -1,0 +1,13 @@
+import { fetch } from 'react-native-fetch-api'; // placeholder fetch polyfill
+
+export async function getSuggestions(): Promise<string> {
+  // Replace URL with actual GenAI API endpoint
+  try {
+    const response = await fetch('https://api.openai.com/v1/suggestions');
+    const data = await response.json();
+    return data.text || 'No suggestion';
+  } catch (e) {
+    console.error(e);
+    return 'Error fetching suggestion';
+  }
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Expo/React Native app skeleton in `app/`
- add basic screens (login, register, dashboard)
- add SQLite-based auth service and GenAI placeholder
- include Jest unit test and project configuration
- update README with project setup and prioritized tasks

## Testing
- `npm test` *(fails: jest not found after removing node_modules)*